### PR TITLE
Default service form object class implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
         paths:
           - vendor/bundle
 
+      # Analyze code
+      - run:
+          name: Analyze code
+          command: bundle exec rubocop --format clang
+
       # Wait for DB
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage
 .env
 
 .vscode
+
+.yardoc
+/docs

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--output-dir docs --markup markdown - docs/*.md

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+  gem "yard"
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 group :development do
   gem "annotate"
   gem "graphql_playground-rails"
+  gem "letter_opener"
   gem "listen", ">= 3.0.5", "< 3.3"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -273,6 +274,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  yard
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     annotate (3.0.2)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
@@ -104,6 +106,10 @@ GEM
     jaro_winkler (1.5.3)
     json (2.2.0)
     jwt (2.2.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -133,6 +139,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.1)
     puma (4.2.1)
       nio4r (~> 2.0)
     pundit (2.1.0)
@@ -259,6 +266,7 @@ DEPENDENCIES
   graphql-errors
   graphql_playground-rails
   hashie
+  letter_opener
   listen (>= 3.0.5, < 3.3)
   pg
   pry-rails

--- a/app/business/form_objects/base_form_object.rb
+++ b/app/business/form_objects/base_form_object.rb
@@ -1,0 +1,6 @@
+module FormObjects
+  # Base class for form object implementations.
+  class BaseFormObject
+    include ActiveModel::Validations
+  end
+end

--- a/app/business/form_objects/base_form_object.rb
+++ b/app/business/form_objects/base_form_object.rb
@@ -1,6 +1,6 @@
 module FormObjects
   # Base class for form object implementations.
   class BaseFormObject
-    include ActiveModel::Validations
+    include ActiveModel::Model
   end
 end

--- a/app/business/form_objects/base_form_object.rb
+++ b/app/business/form_objects/base_form_object.rb
@@ -2,10 +2,5 @@ module FormObjects
   # Base class for form object implementations.
   class BaseFormObject
     include ActiveModel::Validations
-
-    # Initializes the form object
-    def initialize(**args)
-      @args = args
-    end
   end
 end

--- a/app/business/form_objects/base_form_object.rb
+++ b/app/business/form_objects/base_form_object.rb
@@ -2,5 +2,10 @@ module FormObjects
   # Base class for form object implementations.
   class BaseFormObject
     include ActiveModel::Validations
+
+    # Initializes the form object
+    def initialize(**args)
+      @args = args
+    end
   end
 end

--- a/app/business/form_objects/user/create_user.rb
+++ b/app/business/form_objects/user/create_user.rb
@@ -3,6 +3,31 @@ module FormObjects
     # Form object for CreateUser action
     class CreateUser < FormObjects::BaseFormObject
       attr_accessor :email, :name, :password, :password_confirmation
+
+      validates :email, presence: true
+      validates :email, length: { maximum: 255 }
+      validates :email, format: { with: Regex::Email::VALIDATE }
+      validates :name, presence: true
+      validates :name, length: { maximum: 255 }
+      validates :password, presence: true
+      validates :password_confirmation, presence: true
+
+      validate :matching_password_confirmation
+
+      # Form initialization
+      def initialize(email:, name:, password:, password_confirmation:)
+        @email = email
+        @name = name
+        @password = password
+        @password_confirmation = password_confirmation
+      end
+
+      private
+        def matching_password_confirmation
+          if password != password_confirmation
+            errors.add(:password_confirmation)
+          end
+        end
     end
   end
 end

--- a/app/business/form_objects/user/create_user.rb
+++ b/app/business/form_objects/user/create_user.rb
@@ -1,7 +1,7 @@
-module Inputs
+module FormObjects
   module User
     # Form object for CreateUser action
-    class CreateUser < Inputs::BaseInput
+    class CreateUser < FormObjects::BaseFormObject
       attr_accessor :email, :name, :password, :password_confirmation
     end
   end

--- a/app/business/form_objects/user/create_user.rb
+++ b/app/business/form_objects/user/create_user.rb
@@ -6,7 +6,7 @@ module FormObjects
 
       validates :email, presence: true
       validates :email, length: { maximum: 255 }
-      validates :email, format: { with: Regex::Email::VALIDATE }
+      validates :email, format: { with: Devise.email_regexp }
       validates :name, presence: true
       validates :name, length: { maximum: 255 }
       validates :password, presence: true

--- a/app/business/form_objects/user/create_user.rb
+++ b/app/business/form_objects/user/create_user.rb
@@ -5,10 +5,8 @@ module FormObjects
       attr_accessor :email, :name, :password, :password_confirmation
 
       validates :email, presence: true
-      validates :email, length: { maximum: 255 }
       validates :email, format: { with: Devise.email_regexp }
       validates :name, presence: true
-      validates :name, length: { maximum: 255 }
       validates :password, presence: true
       validates :password_confirmation, presence: true
 

--- a/app/business/inputs/base_input.rb
+++ b/app/business/inputs/base_input.rb
@@ -1,6 +1,0 @@
-module Inputs
-  # Base class for input object implementations.
-  class BaseInput
-    include ActiveModel::Validations
-  end
-end

--- a/app/business/services/base_service.rb
+++ b/app/business/services/base_service.rb
@@ -35,13 +35,13 @@ module Services
     # The actual instance method that's invoked. There's hooks for
     # authorization, validation and data / errors rendering.
     #
-    # This method returns a {Hashie::Mash} with the following keys:
+    # This method returns a {::Hashie::Mash} with the following keys:
     # - :data, which can be anything
-    # - :errors, which ideally should be an {Array}
+    # - :errors, which ideally should be an {::Array}
     #
     # It is up to the implementer to supply the values for :data and :errors.
     #
-    # @return [Hashie::Mash] A {Hashie::Mash} consisting of keys :data and :errors
+    # @return [Hashie::Mash] A {::Hashie::Mash} consisting of keys :data and :errors
     def call
       if authorized? && inputs_valid?
         @data = process

--- a/app/business/services/base_service.rb
+++ b/app/business/services/base_service.rb
@@ -95,13 +95,17 @@ module Services
       end
 
       # Hook to render data
+      #
+      # By default it renders the outcome of the `process` method
       def render_data
         @data
       end
 
       # Hook to render errors
+      #
+      # By default it renders the errors of the `@form_object`
       def render_errors
-        []
+        @form_object.errors
       end
   end
 end

--- a/app/business/services/base_service.rb
+++ b/app/business/services/base_service.rb
@@ -84,7 +84,15 @@ module Services
 
       # Hook for validation
       def inputs_valid?
-        false
+        form_object_class = DefaultServiceInput.form_object_class(self.class)
+
+        raise NotImplementedError,
+          "Missing service form object implementation. "\
+          "Expected #{form_object_class} to be implemented, "\
+          "else override the #authorize! hook" unless form_object_class.is_a? Class
+
+        @form_object = form_object_class.new(@args)
+        @form_object.valid?
       end
 
       # Hook to render data

--- a/app/business/services/base_service.rb
+++ b/app/business/services/base_service.rb
@@ -23,11 +23,17 @@ module Services
   # to become permissive instead of restrictive e.g '#inputs_valid?' always returns true
   class BaseService
     # Main entrypoint to the service object
+    #
+    # @param args [Hash] list of named arguments to be consumed by the service
+    #
+    # Refer to {#call}
     def self.call(**args)
       new(args).call
     end
 
     # Initializes the service object
+    #
+    # @param (see {call})
     def initialize(**args)
       @args = args
     end
@@ -54,7 +60,7 @@ module Services
       # The heavy lifting is done within this method. All service objects must at the very
       # minimum implement this method
       #
-      # @return Ideally the output (data) from the processing
+      # @return [Object] Ideally the output (data) from the processing
       def process
         raise NotImplementedError("The instance method '#process' must be implemented for the service object")
       end
@@ -67,6 +73,8 @@ module Services
       # Policies::User#create_user?
       #
       # If the policy is not available, an exception is raised.
+      #
+      # @return [Boolean] True if current user is authorized
       def authorized?
         domain_policy_class, domain_action = DefaultServicePolicy.authorization_components(self.class)
 
@@ -82,6 +90,11 @@ module Services
 
 
       # Hook for validation
+      #
+      # By default the inputs to the service are instantiated into a form object, which then
+      # validates the inputs.
+      #
+      # @return [Boolean] True if the inputs, by default contained in a form object, are valid
       def inputs_valid?
         form_object_class = DefaultServiceFormObject.form_object_class(self.class)
 
@@ -96,14 +109,18 @@ module Services
 
       # Hook to render data
       #
-      # By default it renders the outcome of the `process` method
+      # By default it renders the outcome of the {#process} method
+      #
+      # @return [Object] The outcome of the {#process} method
       def render_data
         @data
       end
 
       # Hook to render errors
       #
-      # By default it renders the errors of the `@form_object`
+      # By default it renders the errors of the form object
+      #
+      # @return [ActiveRecord::Errors]
       def render_errors
         @form_object.errors
       end

--- a/app/business/services/default_service_form_object.rb
+++ b/app/business/services/default_service_form_object.rb
@@ -1,0 +1,25 @@
+module Services
+  # Default form object concerns for service objects
+  class DefaultServiceFormObject
+    # Return the form object class (input class) for a give service object class
+    #
+    # e.g Services::User::CreateUser would map to to FormObjects::User::CreateUser
+    #
+    # Returns the class name if no such class can be constantized.
+    def self.form_object_class(service_object_class)
+      domain_namespace = DomainHelper.to_domain_namespace(service_object_class)
+      service_object_class_name = DomainHelper.to_service_object_class_name(service_object_class)
+
+      form_object_class_name = "FormObjects::" + domain_namespace + "::" + service_object_class_name
+
+      form_object =
+        begin
+          form_object_class_name.constantize
+        rescue
+          form_object_class_name
+        end
+
+      form_object
+    end
+  end
+end

--- a/app/business/services/default_service_input.rb
+++ b/app/business/services/default_service_input.rb
@@ -1,5 +1,0 @@
-module Services
-  # Default input concerns for service objects
-  class DefaultServiceInput
-  end
-end

--- a/app/business/services/domain_helper.rb
+++ b/app/business/services/domain_helper.rb
@@ -8,5 +8,11 @@ module Services
       first, *domain_namespace = service_object_class.name.deconstantize.split("::")
       domain_namespace.join("::")
     end
+
+    # Extracts service object class name only, without the domain details
+    # e.g Services::Domain::Subdomain::CreateSomething becomes CreateSomething
+    def self.to_service_object_class_name(service_object_class)
+      service_object_class.name.demodulize
+    end
   end
 end

--- a/app/business/services/user/create_user.rb
+++ b/app/business/services/user/create_user.rb
@@ -5,17 +5,13 @@ module Services
       private
         def process
           user = ::User.create(
-            email: @args[:email],
-            password: @args[:password],
-            password_confirmation: @args[:password_confirmation],
-            name: @args[:name]
+            email: @form_object.email,
+            password: @form_object.password,
+            password_confirmation: @form_object.password_confirmation,
+            name: @form_object.name
           )
 
           user
-        end
-
-        def inputs_valid?
-          true
         end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
   # - VALIDATIONS
   validates :email, presence: true
   validates :email, length: { maximum: 255 }
-  validates :email, format: { with: Regex::Email::VALIDATE }
+  validates :email, format: { with: Devise.email_regexp }
   validates :name, presence: true
   validates :name, length: { maximum: 255 }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,21 +30,23 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
 
-  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address:              ENV["SMTP_ADDRESS"],
-    port:                 ENV["SMTP_PORT"].to_i,
-    domain:               ENV["SMTP_DOMAIN"],
-    user_name:            ENV["SMTP_USERNAME"],
-    password:             ENV["SMTP_PASSWORD"],
-    authentication:       ENV["SMTP_AUTH"],
-    enable_starttls_auto: ENV["SMTP_ENABLE_STARTTLS_AUTO"] == "true"
-  }
+
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
+  # config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.smtp_settings = {
+  #   address:              ENV["SMTP_ADDRESS"],
+  #   port:                 ENV["SMTP_PORT"].to_i,
+  #   domain:               ENV["SMTP_DOMAIN"],
+  #   user_name:            ENV["SMTP_USERNAME"],
+  #   password:             ENV["SMTP_PASSWORD"],
+  #   authentication:       ENV["SMTP_AUTH"],
+  #   enable_starttls_auto: ENV["SMTP_ENABLE_STARTTLS_AUTO"] == "true"
+  # }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -1,6 +1,0 @@
-module Regex
-  class Email
-    VALIDATE = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-    VALIDATE_OR_EMPTY = /(^$|#{VALIDATE})/i
-  end
-end

--- a/spec/business/form_objects/user/create_user_spec.rb
+++ b/spec/business/form_objects/user/create_user_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe FormObjects::User::CreateUser do
+  describe "password_confirmation" do
+    context "matches password" do
+      it "is valid" do
+        form = described_class.new(
+          email: Faker::Internet.email,
+          name: Faker::Name.name,
+          password: "thisismysupersecurepassword",
+          password_confirmation: "thisismysupersecurepassword"
+        )
+
+        expect(form.valid?).to eq true
+      end
+    end
+
+    context "doesn't match password" do
+      it "is invalid" do
+        form = described_class.new(
+          email: Faker::Internet.email,
+          name: Faker::Name.name,
+          password: "thisismysupersecurepassword",
+          password_confirmation: "thisdoesntmatchthepasswordatall"
+        )
+
+        expect(form.valid?).to eq false
+        expect(form.errors[:password_confirmation]).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/business/services/base_service_spec.rb
+++ b/spec/business/services/base_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Services::BaseService do
         private
           def process
             {
+              process_value: 42,
               authorization_value: authorized?,
               validation_value: inputs_valid?,
             }
@@ -101,6 +102,22 @@ RSpec.describe Services::BaseService do
           Services::Dummy::DoSomethingWithoutFormObject.call
         end.to raise_error(NotImplementedError)
       end
+    end
+  end
+
+  describe "output" do
+    subject do
+      Services::Dummy::DoSomething.call(
+        dummy_input: :bla, yet_another_dummy_input: :blabla
+      )
+    end
+
+    it "returns a hash containing keys 'data' and 'errors'" do
+      expect(subject.keys).to match_array(["data", "errors"])
+    end
+
+    it "returns the errors being contained in ActiveModel::Errors instance" do
+      expect(subject.errors).to be_instance_of(ActiveModel::Errors)
     end
   end
 end

--- a/spec/business/services/base_service_spec.rb
+++ b/spec/business/services/base_service_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Services::BaseService do
+  module FormObjects
+    module Dummy
+      class DoSomething < FormObjects::BaseFormObject
+        def valid?
+          true
+        end
+      end
+    end
+  end
+
+  module Policies
+    class DummyPolicy < Policies::BasePolicy
+      def do_something?
+        true
+      end
+    end
+  end
+
+  module Services
+    module Dummy
+      class DoSomething < Services::BaseService
+        private
+          def process
+            {
+              authorization_value: authorized?,
+              validation_value: inputs_valid?,
+            }
+          end
+      end
+    end
+  end
+
+  module Services
+    module DummyWithoutAuthPolicy
+      class DoSomething < Services::BaseService
+        private
+          def process
+          end
+      end
+    end
+  end
+
+  module Services
+    module Dummy
+      class DoSomethingWithoutFormObject < Services::BaseService
+        private
+          def process
+          end
+
+          # This bypasses the authorization, so we get to test validation instead
+          def authorized?
+            true
+          end
+      end
+    end
+  end
+
+  describe "authorization" do
+    it "attempts to authorize by default" do
+      result = Services::Dummy::DoSomething.call
+      expect(result.data.authorization_value).to eq true
+    end
+
+    context "no authorization policy" do
+      it "raises exception" do
+        expect do
+          Services::DummyWithoutAuthPolicy::DoSomething.call
+        end.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
+  describe "validation" do
+    it "attempts to validate form object by default" do
+      result = Services::Dummy::DoSomething.call
+      expect(result.data.validation_value).to eq true
+    end
+
+    context "no form object" do
+      it "raises exception" do
+        expect do
+          Services::Dummy::DoSomethingWithoutFormObject.call
+        end.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/spec/business/services/base_service_spec.rb
+++ b/spec/business/services/base_service_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Services::BaseService do
   module FormObjects
     module Dummy
       class DoSomething < FormObjects::BaseFormObject
+        attr_accessor :dummy_input, :yet_another_dummy_input
+
+        def initialize(dummy_input:, yet_another_dummy_input:)
+        end
+
         def valid?
           true
         end
@@ -60,7 +65,9 @@ RSpec.describe Services::BaseService do
 
   describe "authorization" do
     it "attempts to authorize by default" do
-      result = Services::Dummy::DoSomething.call
+      result = Services::Dummy::DoSomething.call(
+        dummy_input: :bla, yet_another_dummy_input: :blabla
+      )
       expect(result.data.authorization_value).to eq true
     end
 
@@ -74,8 +81,17 @@ RSpec.describe Services::BaseService do
   end
 
   describe "validation" do
+    it "enforces the keyword arguments based on the form object" do
+      expect do
+        # No arguments supplied
+        Services::Dummy::DoSomething.call
+      end.to raise_error(ArgumentError)
+    end
+
     it "attempts to validate form object by default" do
-      result = Services::Dummy::DoSomething.call
+      result = Services::Dummy::DoSomething.call(
+        dummy_input: :bla, yet_another_dummy_input: :blabla
+      )
       expect(result.data.validation_value).to eq true
     end
 

--- a/spec/business/services/default_service_form_object_spec.rb
+++ b/spec/business/services/default_service_form_object_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Services::DefaultServiceFormObject do
 
   module Services
     module Dummy
-      class DoSomething
+      class DoSomething < Services::BaseService
       end
     end
   end
 
   module Services
     module AnotherDummy
-      class DoSomething
+      class DoSomething < Services::BaseService
       end
     end
   end

--- a/spec/business/services/default_service_form_object_spec.rb
+++ b/spec/business/services/default_service_form_object_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Services::DefaultServiceFormObject do
+  module FormObjects
+    module Dummy
+      class DoSomething < FormObjects::BaseFormObject
+      end
+    end
+  end
+
+  module Services
+    module Dummy
+      class DoSomething
+      end
+    end
+  end
+
+  module Services
+    module AnotherDummy
+      class DoSomething
+      end
+    end
+  end
+
+
+  describe ".form_object_class" do
+    it "returns the expected form object class given the service object class" do
+      expect(described_class.form_object_class(Services::Dummy::DoSomething)).to eq FormObjects::Dummy::DoSomething
+    end
+
+    context "non-existent form object class" do
+      it "returns the name of the expected domain policy glass" do
+        expect(described_class.form_object_class(Services::AnotherDummy::DoSomething)).to eq(
+          "FormObjects::AnotherDummy::DoSomething"
+        )
+      end
+    end
+  end
+end

--- a/spec/business/services/default_service_policy_spec.rb
+++ b/spec/business/services/default_service_policy_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Services::DefaultServicePolicy do
 
   module Services
     module Dummy
-      class DoSomething
+      class DoSomething < Services::BaseService
       end
     end
   end
 
   module Services
     module AnotherDummy
-      class DoSomething
+      class DoSomething < Services::BaseService
       end
     end
   end

--- a/spec/business/services/domain_helper_spec.rb
+++ b/spec/business/services/domain_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Services::DomainHelper do
   module Services
     module Dummy
       module SubDummy
-        class DoSomething
+        class DoSomething < Services::BaseService
         end
       end
     end

--- a/spec/business/services/domain_helper_spec.rb
+++ b/spec/business/services/domain_helper_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe Services::DomainHelper do
       end
     end
   end
+
+  describe ".to_service_object_class_name" do
+    it "returns the service object class name without domain namespace" do
+      expect(
+        described_class.to_service_object_class_name(Services::Dummy::DoSomething)
+        ).to eq "DoSomething"
+    end
+  end
 end

--- a/spec/business/services/user/create_user_spec.rb
+++ b/spec/business/services/user/create_user_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Services::User::CreateUser do
+  it "creates a new user" do
+    args = {
+      email: Faker::Internet.email,
+      name: Faker::Name.name,
+      password: "thisismysupersecurepassword",
+      password_confirmation: "thisismysupersecurepassword"
+    }
+
+    result = described_class.call(args)
+
+    expect(result.data).to be_instance_of User
+    expect(result.data.persisted?).to eq true
+    expect(result.data.email)
+  end
+end

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe GraphqlController, type: :controller do
       it "should raise argument error" do
         expect {
           post :execute, params: { "query" => "{ me { email } }", "variables" => 12 }
-        }.to raise_error
+        }.to raise_error(ArgumentError)
       end
 
       context "environment is development" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,7 +62,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include RequestSpecHelper, type: :request
   config.include GraphqlSpecHelper
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.extend DeviseHelper, type: :controller
 end
 


### PR DESCRIPTION
First service object implementation - `Services::User::CreateUser`, made possible with
- `BaseService`
- `BaseFormObject`
- helper classes to wire and fire default policy and form validation

Along with a bunch of gems.